### PR TITLE
♻️ Update for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export
 build:
 	./build.sh
 
-run:
+run: build
 	docker run -it -e PROM_USER=$$PROM_USER -e PROM_PASS=$$PROM_PASS -e PROM_TARGET=$$PROM_TARGET -e REMOTE_WRITE_URL=$$REMOTE_WRITE_URL app-reachability:latest
 
 .PHONY: build run

--- a/README.md
+++ b/README.md
@@ -17,4 +17,12 @@ To run this container successfully you will need 4 values.
 
 ## Testing locally
 
+### With Docker-Compose
+
 Populate the fields in docker-compose.yml and run `docker compose up`
+
+### With Docker
+
+- Create a .env file `cp .env.example .env`
+- Populate the fields
+- Run `make run`

--- a/config/prometheus.yml.tpl
+++ b/config/prometheus.yml.tpl
@@ -7,6 +7,8 @@ global:
 
 remote_write:
   - url: REMOTE_WRITE_URL #{{REMOTE_WRITE_URL}}
+    tls_config:
+      insecure_skip_verify: true
     basic_auth:
         username: USER
         password: PASS
@@ -26,7 +28,7 @@ scrape_configs:
 
 # Blackbox Exporter probes endpoints over HTTP, HTTPS, DNS, TCP or ICMP protocols, returning detailed metrics about the request,
 # including whether or not it was successful and how long it took to receive a response.
-  - job_name: 'blackbox-http'
+  - job_name: 'app-reachability'
     metrics_path: /probe
     params:
       module: [http_2xx] # Look for a HTTP 200 response


### PR DESCRIPTION
Couple of tweaks to allow easier local testing.
- Remote write now ignores untrusted SSL - this is necessary for testing against dev which uses letsencrypt staging certs.
- updated docs to explain local testing using docker as well as docker-compose.